### PR TITLE
Expose seed_keypair methods for public-key crypto

### DIFF
--- a/sodium/crypto_box.pony
+++ b/sodium/crypto_box.pony
@@ -34,7 +34,7 @@ class val CryptoBoxNonce
     _inner = recover String.append(consume buf) end
 
 primitive CryptoBox
-  fun tag seed_size(): USize => @crypto_box_seedbytes[USize]().usize()
+  fun tag seed_size(): USize       => @crypto_box_seedbytes[USize]().usize()
   fun tag secret_key_size(): USize => @crypto_box_secretkeybytes[USize]().usize()
   fun tag public_key_size(): USize => @crypto_box_publickeybytes[USize]().usize()
   fun tag nonce_size(): USize      => @crypto_box_noncebytes[USize]().usize()
@@ -59,7 +59,7 @@ primitive CryptoBox
     let pk_size = public_key_size(); let pk = _make_buffer(pk_size)
     if 0 != @crypto_box_keypair[_Int](pk.cstring(), sk.cstring()) then error end
     (CryptoBoxSecretKey(consume sk), CryptoBoxPublicKey(consume pk))
-
+  
   fun tag seed_keypair(seed: CryptoBoxSeed): (CryptoBoxSecretKey, CryptoBoxPublicKey)? =>
     let sk_size = secret_key_size(); let sk = _make_buffer(sk_size)
     let pk_size = public_key_size(); let pk = _make_buffer(pk_size)
@@ -67,8 +67,7 @@ primitive CryptoBox
       pk.cstring(), sk.cstring(), seed.cstring()
     ) then error end
     (CryptoBoxSecretKey(consume sk), CryptoBoxPublicKey(consume pk))
-
-
+  
   fun tag apply(m: String, n: CryptoBoxNonce, sk: CryptoBoxSecretKey, pk: CryptoBoxPublicKey): String? =>
     if not (n.is_valid() and pk.is_valid() and sk.is_valid()) then error end
     let buf_size = m.size() + mac_size()

--- a/sodium/crypto_box.pony
+++ b/sodium/crypto_box.pony
@@ -1,6 +1,14 @@
 
 use "lib:sodium"
 
+class val CryptoBoxSeed
+  let _inner: String
+  fun string(): String => _inner
+  fun cstring(): Pointer[U8] tag => _inner.cstring()
+  fun is_valid(): Bool => _inner.size() == CryptoSign.secret_key_size()
+  new val create(buf: (ReadSeq[U8] iso | ReadSeq[U8] val)) =>
+    _inner = recover String.append(consume buf) end
+
 class val CryptoBoxSecretKey
   let _inner: String
   fun string(): String => _inner
@@ -26,6 +34,7 @@ class val CryptoBoxNonce
     _inner = recover String.append(consume buf) end
 
 primitive CryptoBox
+  fun tag seed_size(): USize => @crypto_box_seedbytes[USize]().usize()
   fun tag secret_key_size(): USize => @crypto_box_secretkeybytes[USize]().usize()
   fun tag public_key_size(): USize => @crypto_box_publickeybytes[USize]().usize()
   fun tag nonce_size(): USize      => @crypto_box_noncebytes[USize]().usize()
@@ -50,7 +59,16 @@ primitive CryptoBox
     let pk_size = public_key_size(); let pk = _make_buffer(pk_size)
     if 0 != @crypto_box_keypair[_Int](pk.cstring(), sk.cstring()) then error end
     (CryptoBoxSecretKey(consume sk), CryptoBoxPublicKey(consume pk))
-  
+
+  fun tag seed_keypair(seed: CryptoBoxSeed): (CryptoBoxSecretKey, CryptoBoxPublicKey)? =>
+    let sk_size = secret_key_size(); let sk = _make_buffer(sk_size)
+    let pk_size = public_key_size(); let pk = _make_buffer(pk_size)
+    if 0 != @crypto_box_seed_keypair[_Int](
+      pk.cstring(), sk.cstring(), seed.cstring()
+    ) then error end
+    (CryptoBoxSecretKey(consume sk), CryptoBoxPublicKey(consume pk))
+
+
   fun tag apply(m: String, n: CryptoBoxNonce, sk: CryptoBoxSecretKey, pk: CryptoBoxPublicKey): String? =>
     if not (n.is_valid() and pk.is_valid() and sk.is_valid()) then error end
     let buf_size = m.size() + mac_size()

--- a/sodium/crypto_box.pony
+++ b/sodium/crypto_box.pony
@@ -5,7 +5,7 @@ class val CryptoBoxSeed
   let _inner: String
   fun string(): String => _inner
   fun cstring(): Pointer[U8] tag => _inner.cstring()
-  fun is_valid(): Bool => _inner.size() == CryptoSign.secret_key_size()
+  fun is_valid(): Bool => _inner.size() == CryptoBox.seed_size()
   new val create(buf: (ReadSeq[U8] iso | ReadSeq[U8] val)) =>
     _inner = recover String.append(consume buf) end
 

--- a/sodium/crypto_box.pony
+++ b/sodium/crypto_box.pony
@@ -61,6 +61,7 @@ primitive CryptoBox
     (CryptoBoxSecretKey(consume sk), CryptoBoxPublicKey(consume pk))
   
   fun tag seed_keypair(seed: CryptoBoxSeed): (CryptoBoxSecretKey, CryptoBoxPublicKey)? =>
+    if not seed.is_valid() then error end
     let sk_size = secret_key_size(); let sk = _make_buffer(sk_size)
     let pk_size = public_key_size(); let pk = _make_buffer(pk_size)
     if 0 != @crypto_box_seed_keypair[_Int](

--- a/sodium/crypto_sign.pony
+++ b/sodium/crypto_sign.pony
@@ -56,7 +56,7 @@ primitive CryptoSign
     let pk_size = public_key_size(); let pk = _make_buffer(pk_size)
     if 0 != @crypto_sign_keypair[_Int](pk.cstring(), sk.cstring()) then error end
     (CryptoSignSecretKey(consume sk), CryptoSignPublicKey(consume pk))
-
+  
   fun tag seed_keypair(seed: CryptoSignSeed): (CryptoSignSecretKey, CryptoSignPublicKey)? =>
     let sk_size = secret_key_size(); let sk = _make_buffer(sk_size)
     let pk_size = public_key_size(); let pk = _make_buffer(pk_size)
@@ -64,7 +64,7 @@ primitive CryptoSign
       pk.cstring(), sk.cstring(), seed.cstring()
     ) then error end
     (CryptoSignSecretKey(consume sk), CryptoSignPublicKey(consume pk))
-
+  
   fun tag apply(m: String, sk: CryptoSignSecretKey): String? =>
     if not sk.is_valid() then error end
     var buf_size: USize = m.size() + mac_size()

--- a/sodium/crypto_sign.pony
+++ b/sodium/crypto_sign.pony
@@ -58,6 +58,7 @@ primitive CryptoSign
     (CryptoSignSecretKey(consume sk), CryptoSignPublicKey(consume pk))
   
   fun tag seed_keypair(seed: CryptoSignSeed): (CryptoSignSecretKey, CryptoSignPublicKey)? =>
+    if not seed.is_valid() then error end
     let sk_size = secret_key_size(); let sk = _make_buffer(sk_size)
     let pk_size = public_key_size(); let pk = _make_buffer(pk_size)
     if 0 != @crypto_sign_seed_keypair[_Int](

--- a/sodium/crypto_sign.pony
+++ b/sodium/crypto_sign.pony
@@ -5,7 +5,7 @@ class val CryptoSignSeed
   let _inner: String
   fun string(): String => _inner
   fun cstring(): Pointer[U8] tag => _inner.cstring()
-  fun is_valid(): Bool => _inner.size() == CryptoSign.secret_key_size()
+  fun is_valid(): Bool => _inner.size() == CryptoSign.seed_size()
   new val create(buf: (ReadSeq[U8] iso | ReadSeq[U8] val)) =>
     _inner = recover String.append(consume buf) end
 

--- a/sodium/test/crypto_box_test.pony
+++ b/sodium/test/crypto_box_test.pony
@@ -42,18 +42,18 @@ class CryptoBoxTest is UnitTest
     ///
     // Key pairs generated with seeds
     
-    (let sks, let pks) = CryptoBox.seed_keypair(CryptoBoxSeed("Hello seeds!"))
-
+    (let sks, let pks) = CryptoBox.seed_keypair(CryptoBoxSeed("Hello seeds!                    "))
+    
     h.assert_eq[USize](sks.string().size(), CryptoBox.secret_key_size())
     h.assert_eq[USize](pks.string().size(), CryptoBox.public_key_size())
     
-    (let sks', let pks') = CryptoBox.seed_keypair(CryptoBoxSeed("Hello seeds!"))
-
+    (let sks', let pks') = CryptoBox.seed_keypair(CryptoBoxSeed("Hello seeds!                    "))
+    
     h.assert_eq[String](sks.string(), sks'.string())
     h.assert_eq[String](pks.string(), pks'.string())
     
-    (let sksb, let pksb) = CryptoBox.seed_keypair(CryptoBoxSeed("Hello world!"))
-
+    (let sksb, let pksb) = CryptoBox.seed_keypair(CryptoBoxSeed("Hello world!                    "))
+    
     h.assert_ne[String](sks.string(), sksb.string())
     h.assert_ne[String](pks.string(), pksb.string())
     

--- a/sodium/test/crypto_box_test.pony
+++ b/sodium/test/crypto_box_test.pony
@@ -38,7 +38,25 @@ class CryptoBoxTest is UnitTest
     try CryptoBox.open(crypt', nonce', csk, bpk)
       h.fail("Cyril shouldn't be able to open Bob's message to Alice.")
     end
-    
+
+    ///
+    // Key pairs generated with seeds
+
+    (let sks, let pks) = CryptoBox.seed_keypair(CryptoBoxSeed("Hello seeds!"))
+
+    h.assert_eq[USize](sks.string().size(), CryptoBox.secret_key_size())
+    h.assert_eq[USize](pks.string().size(), CryptoBox.public_key_size())
+
+    (let sks', let pks') = CryptoBox.seed_keypair(CryptoBoxSeed("Hello seeds!"))
+
+    h.assert_eq[String](sks.string(), sks'.string())
+    h.assert_eq[String](pks.string(), pks'.string())
+
+    (let sksb, let pksb) = CryptoBox.seed_keypair(CryptoBoxSeed("Hello world!"))
+
+    h.assert_ne[String](sks.string(), sksb.string())
+    h.assert_ne[String](pks.string(), pksb.string())
+
     ///
     // Scalar multiplication (Diffie-Hellman) tests
     

--- a/sodium/test/crypto_box_test.pony
+++ b/sodium/test/crypto_box_test.pony
@@ -38,25 +38,25 @@ class CryptoBoxTest is UnitTest
     try CryptoBox.open(crypt', nonce', csk, bpk)
       h.fail("Cyril shouldn't be able to open Bob's message to Alice.")
     end
-
+    
     ///
     // Key pairs generated with seeds
-
+    
     (let sks, let pks) = CryptoBox.seed_keypair(CryptoBoxSeed("Hello seeds!"))
 
     h.assert_eq[USize](sks.string().size(), CryptoBox.secret_key_size())
     h.assert_eq[USize](pks.string().size(), CryptoBox.public_key_size())
-
+    
     (let sks', let pks') = CryptoBox.seed_keypair(CryptoBoxSeed("Hello seeds!"))
 
     h.assert_eq[String](sks.string(), sks'.string())
     h.assert_eq[String](pks.string(), pks'.string())
-
+    
     (let sksb, let pksb) = CryptoBox.seed_keypair(CryptoBoxSeed("Hello world!"))
 
     h.assert_ne[String](sks.string(), sksb.string())
     h.assert_ne[String](pks.string(), pksb.string())
-
+    
     ///
     // Scalar multiplication (Diffie-Hellman) tests
     

--- a/sodium/test/crypto_sign_test.pony
+++ b/sodium/test/crypto_sign_test.pony
@@ -58,25 +58,25 @@ class CryptoSignTest is UnitTest
     try CryptoSign.verify_detached("My message!", CryptoSign.keypair()._2, mac)
       h.fail("Shouldn't verify if given the wrong key.")
     end
-
+    
     ///
     // Key pairs generated with seeds
-
-    (let sks, let pks) = CryptoSign.seed_keypair(CryptoSignSeed("Hello seeds!"))
-
+    
+    (let sks, let pks) = CryptoSign.seed_keypair(CryptoSignSeed("Hello seeds!                    "))
+    
     h.assert_eq[USize](sks.string().size(), CryptoSign.secret_key_size())
     h.assert_eq[USize](pks.string().size(), CryptoSign.public_key_size())
     
-    (let sks', let pks') = CryptoSign.seed_keypair(CryptoSignSeed("Hello seeds!"))
-
+    (let sks', let pks') = CryptoSign.seed_keypair(CryptoSignSeed("Hello seeds!                    "))
+    
     h.assert_eq[String](sks.string(), sks'.string())
     h.assert_eq[String](pks.string(), pks'.string())
     
-    (let sksb, let pksb) = CryptoSign.seed_keypair(CryptoSignSeed("Hello world!"))
-
+    (let sksb, let pksb) = CryptoSign.seed_keypair(CryptoSignSeed("Hello world!                    "))
+    
     h.assert_ne[String](sks.string(), sksb.string())
     h.assert_ne[String](pks.string(), pksb.string())
-
+    
     ///
     // Convert to CryptoBox (curve) keys and use with normal CryptoBox keys
     

--- a/sodium/test/crypto_sign_test.pony
+++ b/sodium/test/crypto_sign_test.pony
@@ -58,7 +58,25 @@ class CryptoSignTest is UnitTest
     try CryptoSign.verify_detached("My message!", CryptoSign.keypair()._2, mac)
       h.fail("Shouldn't verify if given the wrong key.")
     end
-    
+
+    ///
+    // Key pairs generated with seeds
+
+    (let sks, let pks) = CryptoSign.seed_keypair(CryptoSignSeed("Hello seeds!"))
+
+    h.assert_eq[USize](sks.string().size(), CryptoSign.secret_key_size())
+    h.assert_eq[USize](pks.string().size(), CryptoSign.public_key_size())
+
+    (let sks', let pks') = CryptoSign.seed_keypair(CryptoSignSeed("Hello seeds!"))
+
+    h.assert_eq[String](sks.string(), sks'.string())
+    h.assert_eq[String](pks.string(), pks'.string())
+
+    (let sksb, let pksb) = CryptoSign.seed_keypair(CryptoSignSeed("Hello world!"))
+
+    h.assert_ne[String](sks.string(), sksb.string())
+    h.assert_ne[String](pks.string(), pksb.string())
+
     ///
     // Convert to CryptoBox (curve) keys and use with normal CryptoBox keys
     

--- a/sodium/test/crypto_sign_test.pony
+++ b/sodium/test/crypto_sign_test.pony
@@ -66,12 +66,12 @@ class CryptoSignTest is UnitTest
 
     h.assert_eq[USize](sks.string().size(), CryptoSign.secret_key_size())
     h.assert_eq[USize](pks.string().size(), CryptoSign.public_key_size())
-
+    
     (let sks', let pks') = CryptoSign.seed_keypair(CryptoSignSeed("Hello seeds!"))
 
     h.assert_eq[String](sks.string(), sks'.string())
     h.assert_eq[String](pks.string(), pks'.string())
-
+    
     (let sksb, let pksb) = CryptoSign.seed_keypair(CryptoSignSeed("Hello world!"))
 
     h.assert_ne[String](sks.string(), sksb.string())


### PR DESCRIPTION
This way a key pair can be generated deterministically from a (32-byte) seed. It's my first contribution to anything Pony so any feedback is welcome. I'm unsure if you'd normally dedicate a whole class/type to something like a seed, but I looked at what you had done an did the same. You also had a lot of lingering whitespace which I've respected, but haven't added in my contribution. Is this intentional or coincidental? I'll add it if on purpose.
